### PR TITLE
bug fix when saving token to jwt_tokens database table

### DIFF
--- a/lib/TokenProviders/JwtDatabaseProvider.ts
+++ b/lib/TokenProviders/JwtDatabaseProvider.ts
@@ -121,7 +121,7 @@ export default class JwtDatabaseProvider extends AbstractDatabaseProvider implem
             token: token.tokenHash,
             type: token.type,
             refresh_token: token.refreshToken,
-            refresh_token_expires_at: token.refreshTokenExpiresAt,
+            refresh_token_expires_at: token.refreshTokenExpiresAt?.toFormat(client.dialect.dateTimeFormat),
             expires_at: token.expiresAt ? token.expiresAt.toFormat(client.dialect.dateTimeFormat) : null,
             created_at: DateTime.local().toFormat(client.dialect.dateTimeFormat),
             ...token.meta,


### PR DESCRIPTION
When calling the method generate or login, an error occurred while saving the token to the jwt_tokens table

```
const user = await User.find(1);
const jwt = await auth.use("jwt").generate(user);
//or using .login():
//const jwt = await auth.use("jwt").login(user);
```

Error

"insert into `jwt_tokens` (`created_at`, `expires_at`, `name`, `refresh_token`, `refresh_token_expires_at`, `token`, `type`, `user_id`) values ('2022-01-01 22:39:25', '2022-01-01 22:49:25', 'JWT Access Token', 'c351631a1e5eddc65351f4ef9e3211af4b5a48852c58dba0f3b37efed91dfaf8', 2022-01-11 22:39:25.544 +00:00, '82e0d513b1cdbca2ceee59610701fb2566b7725cab95214095a7f8e6c0622f0e', 'api', 1) - ER_WRONG_VALUE_COUNT_ON_ROW: Column count doesn't match value count at row 1"

refresh_token_expires_at must be a string value