### PR TITLE
feat (guard): add possibility to get access token from cookie

### DIFF
--- a/adonis-typings/index.ts
+++ b/adonis-typings/index.ts
@@ -1,3 +1,5 @@
+import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext';
+import { Exception } from '@adonisjs/core/build/standalone';
 declare module "@ioc:Adonis/Addons/Jwt" {
     import {
         DatabaseTokenProviderConfig,
@@ -89,6 +91,11 @@ declare module "@ioc:Adonis/Addons/Jwt" {
          * User provider
          */
         provider: ProvidersList[Provider]["config"];
+
+        /**
+         * Default JWT uses the ctx.request.header("Authorization")
+         */
+        getBearerToken: (ctx: HttpContextContract) => string | Exception
     };
 
     /**

--- a/lib/Guards/JwtGuard.ts
+++ b/lib/Guards/JwtGuard.ts
@@ -465,7 +465,11 @@ export class JWTGuard extends BaseGuard<"jwt"> implements JWTGuardContract<any, 
      */
     private getBearerToken(): string {
         if(this.config.getBearerToken) {
-            return this.config.getBearerToken(this.ctx);
+           try {
+               return  this.config.getBearerToken(this.ctx);
+           } catch (error) {
+            throw new JwtAuthenticationException(error);
+           }
         }
         /**
          * Ensure the "Authorization" header value exists

--- a/lib/Guards/JwtGuard.ts
+++ b/lib/Guards/JwtGuard.ts
@@ -464,6 +464,9 @@ export class JWTGuard extends BaseGuard<"jwt"> implements JWTGuardContract<any, 
      * Returns the bearer token
      */
     private getBearerToken(): string {
+        if(this.config.getBearerToken) {
+            return this.config.getBearerToken(this.ctx);
+        }
         /**
          * Ensure the "Authorization" header value exists
          */


### PR DESCRIPTION
I'm using this library in a personal project and I need to get access token from cookies and it is not possible so far.
This change allow us to provide the access token to the guard class from auth.config file 

e.g:
```js
//config/auth.ts
 basic: {
 },
jwt: {
  ...{ALL_JWT_CONFIG}
  getBearerToken: (ctx) => {
      const token = ctx.request.cookie('authorization')
      if (token) {
        return token
      }
      return ''
   },
}
```

if nothing was provided in the auth.config file, the default getBearerToken will be executed